### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/fonts/icomoon/demo-files/demo.js
+++ b/fonts/icomoon/demo-files/demo.js
@@ -15,7 +15,7 @@ document.body.addEventListener("click", function(e) {
         testDrive = document.getElementById('testDrive'),
         testText = document.getElementById('testText');
     function updateTest() {
-        testDrive.innerHTML = testText.value || String.fromCharCode(160);
+        testDrive.textContent = testText.value || String.fromCharCode(160);
         if (window.icomoonLiga) {
             window.icomoonLiga(testDrive);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/rajg2023/careerportfolio/security/code-scanning/1](https://github.com/rajg2023/careerportfolio/security/code-scanning/1)

To fix the problem, we need to ensure that any text assigned to `innerHTML` is properly escaped to prevent it from being interpreted as HTML. This can be achieved by using `textContent` instead of `innerHTML`, which will treat the input as plain text rather than HTML.

The best way to fix the problem without changing existing functionality is to replace the assignment to `innerHTML` with an assignment to `textContent`. This change should be made on line 18 of the provided code snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
